### PR TITLE
feat: Bump to latest TFE provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ Apache 2 Licensed. See [LICENSE](LICENSE) for full details.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.6, < 2.0 |
-| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~> 0.38.0 |
+| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~> 0.42.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.38.0 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.42.0 |
 
 ## Resources
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.38.0"
+      version = "~> 0.42.0"
     }
   }
 }


### PR DESCRIPTION
Related to: n/a
<!-- Issue this PR is connected to -->

## Overview of change

<!-- Description of change -->
Update constraints to use latest upstream TFE provider: https://github.com/hashicorp/terraform-provider-tfe/releases/tag/v0.42.0 and enable projects support.

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [x] README.md has been updated after any changes to variables and outputs.

