### PR TITLE
feat: Bump TFE provider version

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -29,7 +29,6 @@ jobs:
       matrix:
         os: [ubuntu-latest] #, windows-latest]
         tf-ver:
-          - '~1.0' # Same as 1.0.x
           - '~1.1' # Same as 1.1.x
           - '~1.2' # Same as 1.2.x
           - '~1.3' # Same as 1.3.x

--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ Apache 2 Licensed. See [LICENSE](LICENSE) for full details.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.6, < 2.0 |
-| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~> 0.45.0 |
+| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~> 0.48.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.45.0 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.48.0 |
 
 ## Resources
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.45.0"
+      version = "~> 0.48.0"
     }
   }
 }


### PR DESCRIPTION
Related to: #
<!-- Issue this PR is connected to -->

## Overview of change

<!-- Description of change -->

TFE bumped to 0.48.0

### Checklist

- [x] README.md has been updated after any changes to variables and outputs.

